### PR TITLE
variable fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,9 +15,9 @@ default.oozie.base_dir                 = "/srv/oozie-" + "#{node.oozie.version}"
 default.oozie.home                     = "/srv/oozie"
 
 
-default.oozie.email.smtp               = node.hopsworks.smtp
-default.oozie.email.smtp.username      = ""
-default.oozie.email.smtp.port          = 587
-default.oozie.email.smtp.password      = ""
+default.oozie.smtp.host         = node.hopsworks.smtp
+default.oozie.smtp.username     = ""
+default.oozie.smtp.port         = 587
+default.oozie.smtp.password     = ""
 # email address of sender
-default.oozie.email.from.address       = ""
+default.oozie.from.address      = ""

--- a/templates/default/oozie-site.xml.erb
+++ b/templates/default/oozie-site.xml.erb
@@ -7,9 +7,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -98,7 +98,7 @@
 
 <property>
     <name>oozie.email.smtp.host</name>
-    <value><%= node.oozie.smtp %></value>
+    <value><%= node.oozie.smtp.host %></value>
 </property>
 
 <property>


### PR DESCRIPTION
variables where wrongly name

default.oozie.email.smtp was a string then
default.oozie.email.smtp.username was expecting it to be a hash

in attributes default we had variables as

default.oozie.email.*

and in oozie.site.xml

node.oozie.*

they dont match

Also this error when running 

==> default: Recipe Compile Error in /tmp/vagrant-chef/2f0128111863ecb2ef042cefe08c850e/cookbooks/oozie/recipes/default.rb
==> default: ================================================================================
==> default: ArgumentError
==> default: -------------
==> default: You must supply a name when declaring a oozie_db resource
==> default: Cookbook Trace:
==> default: ---------------
==> default:   /tmp/vagrant-chef/2f0128111863ecb2ef042cefe08c850e/cookbooks/oozie/recipes/default.rb:110:in `from_file'
==> default: Relevant File Content:
==> default: ----------------------
==> default: /tmp/vagrant-chef/2f0128111863ecb2ef042cefe08c850e/cookbooks/oozie/recipes/default.rb:
==> default: 
==> default: 103:       web_port 11000
==> default: 104:     end
==> default: 105:  end
==> default: 106:  
==> default: 107:  
==> default: 108:  firstNN = private_recipe_ip("apache_hadoop", "nn") + ":#{node.apache_hadoop.nn.port}"
==> default: 109:  
==> default: 110>> oozie_db do
==> default: 111:    nn firstNN
==> default: 112:    action :create
==> default: 113:  end
==> default: 114: 
